### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Achilles - Django AJAX Framework
 ================================
 
-.. image:: https://pypip.in/v/django-achilles/badge.png
+.. image:: https://img.shields.io/pypi/v/django-achilles.svg
   :target: https://pypi.python.org/pypi/django-achilles
 
 .. image:: https://secure.travis-ci.org/exekias/django-achilles.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-achilles))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-achilles`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.